### PR TITLE
Fixing an out-of-date call to uuid.NewV1()

### DIFF
--- a/options.go
+++ b/options.go
@@ -30,10 +30,7 @@ type ClientOptions struct {
 
 // NewClientOptions will create a new ClientClientOptions type with some default values.
 func NewClientOptions() *ClientOptions {
-	id, err := uuid.NewV1()
-	if err != nil {
-		panic(err)
-	}
+	id := uuid.NewV1()
 
 	// Create new client options with defaults
 	o := &ClientOptions{


### PR DESCRIPTION
The newest version of the uuid package doesn't have the potential for an error object, so it doesn't return one.  Just updating the package to fix compile-time errors.