### PR TITLE
fixed the uuid.NewV1() to uuid.NewV4()

### DIFF
--- a/options.go
+++ b/options.go
@@ -30,7 +30,7 @@ type ClientOptions struct {
 
 // NewClientOptions will create a new ClientClientOptions type with some default values.
 func NewClientOptions() *ClientOptions {
-	id := uuid.NewV1()
+	id, _ := uuid.NewV4()
 
 	// Create new client options with defaults
 	o := &ClientOptions{


### PR DESCRIPTION
A compilation error occurred:`emitter-io/go/options.go:33:18: multiple-value uuid.NewV1() in single-value context`.
This issue is due to an upstream API change in the [github.com/satori/go.uuid](https://github.com/satori/go.uuid) package, specifically the change for [satori/go.uuid#18](
https://github.com/satori/go.uuid/issues/18).