### PR TITLE
Ignore 'error' returned from NewV1 to make this work with newest go.uuid

### DIFF
--- a/options.go
+++ b/options.go
@@ -30,8 +30,8 @@ type ClientOptions struct {
 
 // NewClientOptions will create a new ClientClientOptions type with some default values.
 func NewClientOptions() *ClientOptions {
-	id := uuid.NewV1()
-
+	id, _ := uuid.NewV1()
+  
 	// Create new client options with defaults
 	o := &ClientOptions{
 		Servers:              nil,


### PR DESCRIPTION
This band-aids "multiple-value uuid.NewV1() in single-value context" error upon trying to install the emitter-client package.