### PR TITLE
Private links now disappeared to make place for private channels

### DIFF
--- a/v2/emitter.go
+++ b/v2/emitter.go
@@ -360,31 +360,6 @@ func (c *Client) GenerateKey(key, channel, permissions string, ttl int) (string,
 	return "", ErrUnmarshal
 }
 
-// CreatePrivateLink sends a request to create a private link.
-func (c *Client) CreatePrivateLink(key, channel, name string, optionalHandler MessageHandler, options ...Option) (*Link, error) {
-	resp, err := c.request("link", &linkRequest{
-		Name:      name,
-		Key:       key,
-		Channel:   formatTopic("", channel, options),
-		Subscribe: optionalHandler != nil,
-		Private:   true,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Cast the response and return it
-	if result, ok := resp.(*Link); ok {
-		if optionalHandler != nil {
-			c.handlers.AddHandler(result.Channel, optionalHandler)
-		}
-
-		return result, nil
-	}
-
-	return nil, ErrUnmarshal
-}
-
 // CreateLink sends a request to create a default link.
 func (c *Client) CreateLink(key, channel, name string, optionalHandler MessageHandler, options ...Option) (*Link, error) {
 	resp, err := c.request("link", &linkRequest{
@@ -392,7 +367,6 @@ func (c *Client) CreateLink(key, channel, name string, optionalHandler MessageHa
 		Key:       key,
 		Channel:   formatTopic("", channel, options),
 		Subscribe: optionalHandler != nil,
-		Private:   false,
 	})
 
 	if err != nil {

--- a/v2/types.go
+++ b/v2/types.go
@@ -123,7 +123,6 @@ type linkRequest struct {
 	Key       string `json:"key"`       // The key for the channel.
 	Channel   string `json:"channel"`   // The channel name for the shortcut.
 	Subscribe bool   `json:"subscribe"` // Specifies whether the broker should auto-subscribe.
-	Private   bool   `json:"private"`   // Specifies whether the broker should generate a private link.
 }
 
 // meResponse represents information about the client.


### PR DESCRIPTION
generated through the keygen command used with an extendable key.