### PR TITLE
Remove CreatePrivateLink from tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,7 @@ func main() {
 	fmt.Println("[emitter] <- [B] publishing to 'sdk-integration-test/'")
 	c.Publish(key, "sdk-integration-test/", "hello")
 
-	// Ask to create a private link
-	fmt.Println("[emitter] <- [B] creating a private link")
-	link, _ := c.CreatePrivateLink(key, "sdk-integration-test/", "1", func(_ *emitter.Client, msg emitter.Message) {
-		fmt.Printf("[emitter] -> [B] received from private link: '%s' topic: '%s'\n", msg.Payload(), msg.Topic())
-	})
-	fmt.Println("[emitter] -> [B] received link " + link.Channel)
-
-	// Publish to the private link
-	fmt.Println("[emitter] <- [B] publishing to private link")
-	c.PublishWithLink("1", "hi from private link")
+	select {}  // wait forever without busy loop - Ctrl-c to stop
 }
 ```
 

--- a/sample/main.go
+++ b/sample/main.go
@@ -58,15 +58,4 @@ func clientB() {
 	// Publish to the channel
 	fmt.Println("[emitter] <- [B] publishing to 'sdk-integration-test/'")
 	c.Publish(key, "sdk-integration-test/", "hello")
-
-	// Ask to create a private link
-	fmt.Println("[emitter] <- [B] creating a private link")
-	link, _ := c.CreatePrivateLink(key, "sdk-integration-test/", "1", func(_ *emitter.Client, msg emitter.Message) {
-		fmt.Printf("[emitter] -> [B] received from private link: '%s' topic: '%s'\n", msg.Payload(), msg.Topic())
-	})
-	fmt.Println("[emitter] -> [B] received link " + link.Channel)
-
-	// Publish to the private link
-	fmt.Println("[emitter] <- [B] publishing to private link")
-	c.PublishWithLink("1", "hi from private link")
 }

--- a/v2/emitter_test.go
+++ b/v2/emitter_test.go
@@ -60,18 +60,6 @@ func clientB(t *testing.T) {
 	fmt.Println("[emitter] <- [B] publishing to 'sdk-integration-test/'")
 	err = c.Publish(key, "sdk-integration-test/", "hello")
 	assert.NoError(t, err)
-
-	// Ask to create a private link
-	fmt.Println("[emitter] <- [B] creating a private link")
-	link, err := c.CreatePrivateLink(key, "sdk-integration-test/", "1", func(_ *Client, msg Message) {
-		fmt.Printf("[emitter] -> [B] received from private link: '%s' topic: '%s'\n", msg.Payload(), msg.Topic())
-	})
-	assert.NoError(t, err)
-	assert.NotNil(t, link)
-
-	// Publish to the private link
-	fmt.Println("[emitter] <- [B] publishing to private link")
-	c.PublishWithLink("1", "hi from private link")
 }
 
 func TestFormatTopic(t *testing.T) {


### PR DESCRIPTION
In https://github.com/emitter-io/go/commit/b0d1a898b69d0a58c9c9b3092c9e8e2214527fdc the `CreatePrivateLink` method was removed but other references were left in. This PR removes them to reduce confusion.