### PR TITLE
MQTT topic matcher

### DIFF
--- a/v2/emitter.go
+++ b/v2/emitter.go
@@ -66,7 +66,7 @@ func NewClient(options ...func(*Client)) *Client {
 		opts:     mqtt.NewClientOptions(),
 		timeout:  60 * time.Second,
 		store:    new(store),
-		handlers: newTrie(),
+		handlers: NewTrie(),
 	}
 
 	// Set handlers
@@ -301,8 +301,11 @@ func (c *Client) Subscribe(key string, channel string, optionalHandler MessageHa
 		c.handlers.AddHandler(channel, optionalHandler)
 	}
 
+	// https://github.com/eclipse/paho.mqtt.golang/blob/master/topic.go#L78
+	topic := strings.ReplaceAll(formatTopic(key, channel, options), "#/", "#")
+
 	// Issue subscribe
-	token := c.conn.Subscribe(formatTopic(key, channel, options), 0, nil)
+	token := c.conn.Subscribe(topic, 0, nil)
 	return c.do(token)
 }
 

--- a/v2/options.go
+++ b/v2/options.go
@@ -7,6 +7,15 @@ import (
 	"time"
 )
 
+// WithMatcher If "mqtt", then topic matching would follow MQTT specification.
+func WithMatcher(matcher string) func(*Client) {
+	return func(c *Client) {
+		if "mqtt" == matcher {
+			c.handlers = NewTrieMQTT()
+		}
+	}
+}
+
 // WithBrokers configures broker URIs to connect to. The format should be scheme://host:port
 // Where "scheme" is one of "tcp", "ssl", or "ws", "host" is the ip-address (or hostname)
 // and "port" is the port on which the broker is accepting connections.

--- a/v2/subtrie_test.go
+++ b/v2/subtrie_test.go
@@ -12,7 +12,7 @@ func TestRoute(t *testing.T) {
 }
 
 func TestTrieMatch(t *testing.T) {
-	m := newTrie()
+	m := NewTrie()
 	testPopulateWithStrings(m, []string{
 		"a/",
 		"a/b/c/",


### PR DESCRIPTION
I made a patch so the topic matching would follow MQTT specification.

```go
func main() {
    key := "<key>"

    c, _ := emitter.Connect("tcp://127.0.0.1:8080", func(c *emitter.Client, msg emitter.Message) {
        fmt.Printf("[emitter] -> [unknown] topic: %s payload: %s\n", msg.Topic(), msg.Payload())
    }, emitter.WithMatcher("mqtt"))

    fmt.Println("[emitter] <- subscribing to 'demo/#'")
    c.Subscribe(key, "demo/#", func(c *emitter.Client, msg emitter.Message) {
        fmt.Printf("[emitter] -> [demo/#] topic: %s payload: %s\n", msg.Topic(), msg.Payload())
    })

    fmt.Println("[emitter] <- publishing to 'demo/test'")
    c.Publish(key, "demo/test", "hello, mqtt!")

    select {}
}
```