### PR TITLE
return channel in generate key

### DIFF
--- a/v2/emitter.go
+++ b/v2/emitter.go
@@ -355,7 +355,7 @@ func (c *Client) Presence(key, channel string, status, changes bool) error {
 }
 
 // GenerateKey sends a key generation request to the broker
-func (c *Client) GenerateKey(key, channel, permissions string, ttl int) (string, error) {
+func (c *Client) GenerateKey(key, channel, permissions string, ttl int) (string, string, error) {
 	resp, err := c.request("keygen", &keygenRequest{
 		Key:     key,
 		Channel: channel,
@@ -363,14 +363,14 @@ func (c *Client) GenerateKey(key, channel, permissions string, ttl int) (string,
 		TTL:     ttl,
 	})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	// Cast the response and return it
 	if result, ok := resp.(*keyGenResponse); ok {
-		return result.Key, nil
+		return result.Key, result.Channel, nil
 	}
-	return "", ErrUnmarshal
+	return "", "", ErrUnmarshal
 }
 
 // BlockKey sends a request to block a key.


### PR DESCRIPTION
In https://github.com/emitter-io/emitter/issues/264#issuecomment-531806899
`keygen` will return a private channel with a key. So the channel should be returned