### PR TITLE
Extracts the call to the presence handler from switch-case destined for requests

### DIFF
--- a/v2/emitter.go
+++ b/v2/emitter.go
@@ -150,15 +150,8 @@ func (c *Client) onMessage(_ mqtt.Client, m mqtt.Message) {
 		return
 	}
 
-	// `onError` and `onResponse` read the callbacks store when calling
-	// the `NotifyResponse`. See the comments in the `request` function.
-	c.RLock()
-	defer c.RUnlock()
-
-	switch {
-
 	// Dispatch presence handler
-	case c.presence != nil && strings.HasPrefix(m.Topic(), "emitter/presence/"):
+	if c.presence != nil && strings.HasPrefix(m.Topic(), "emitter/presence/") {
 		var msg presenceMessage
 		if err := json.Unmarshal(m.Payload(), &msg); err != nil {
 			log.Println("emitter:", err.Error())
@@ -177,6 +170,15 @@ func (c *Client) onMessage(_ mqtt.Client, m mqtt.Message) {
 		}
 
 		c.presence(c, r)
+		return
+	}
+
+	// `onError` and `onResponse` read the callbacks store when calling
+	// the `NotifyResponse`. See the comments in the `request` function.
+	c.RLock()
+	defer c.RUnlock()
+
+	switch {
 
 	// Dispatch errors handler
 	case strings.HasPrefix(m.Topic(), "emitter/error/"):


### PR DESCRIPTION
In onMessage, that occurs when the MQTT client receives a message, there is a switch protected by a mutex for each case of a call to c.request that results in a "dispatch" of the response. However, Presence doesn't use that pattern and has therefore no reason to be inside that switch-case.