### PR TITLE
[IMP] Making a presence call an rpc for consistency

### DIFF
--- a/v2/types.go
+++ b/v2/types.go
@@ -93,8 +93,8 @@ type presenceRequest struct {
 	Changes bool   `json:"changes"`
 }
 
-// presenceMessage represents a presence message, for partial unmarshal
-type presenceMessage struct {
+// presenceResponse represents a presence message, for partial unmarshal
+type presenceResponse struct {
 	Request uint16          `json:"req,omitempty"`
 	Event   string          `json:"event"`
 	Channel string          `json:"channel"`
@@ -102,10 +102,15 @@ type presenceMessage struct {
 	Who     json.RawMessage `json:"who"`
 }
 
+// RequestID returns the request ID for the response.
+func (r *presenceResponse) RequestID() uint16 {
+	return r.Request
+}
+
 // PresenceEvent  represents a response from emitter broker which contains
 // presence state or a join/leave notification.
 type PresenceEvent struct {
-	presenceMessage
+	presenceResponse
 	Who []PresenceInfo
 }
 


### PR DESCRIPTION
@kelindar **Please be careful when reviewing this PR.**

NOTE that this RPC, in case of a status flag set to false,
will only work if the broker send an empty response instead
of just nil.
See https://github.com/emitter-io/emitter/pull/427

Before, when calling Presence, you would receive all responses on the
presence event handler. Both the status response, and the change events.
Now, you receive the status as a result of the call to presence like any
RPC, and only receive the changes (subscribe, unsubscribe) on the handler.